### PR TITLE
changed scope from deceased to player

### DIFF
--- a/mod files/common/script_values/inherichance_script_values.txt
+++ b/mod files/common/script_values/inherichance_script_values.txt
@@ -2,7 +2,7 @@
 	value = 0
 	every_heir_to_title = {
 		limit = {
-			holder = scope:deceased
+			holder = scope:player
 			is_leased_out = no
 			tier <= tier_county
 		}
@@ -13,7 +13,7 @@
 			is_leased_out = no
 			tier <= tier_county
 			exists = previous_holder
-			previous_holder = scope:deceased
+			previous_holder = scope:player
 		}
 		add = 1
 	}
@@ -24,7 +24,7 @@ inherichance_title_rank = {
 	value = 0
 	ordered_heir_to_title = {
 		limit = {
-			holder = scope:deceased
+			holder = scope:player
 			is_leased_out = no
 		}
 		position = 0
@@ -35,7 +35,7 @@ inherichance_title_rank = {
 		ordered_held_title = {
 			limit = {
 				exists = previous_holder
-				previous_holder = scope:deceased
+				previous_holder = scope:player
 			}
 			position = 0
 			order_by = tier

--- a/mod files/common/script_values/inherichance_script_values.txt
+++ b/mod files/common/script_values/inherichance_script_values.txt
@@ -24,7 +24,7 @@ inherichance_title_rank = {
 	value = 0
 	ordered_heir_to_title = {
 		limit = {
-			holder = scope:player
+			holder = scope:deceased
 			is_leased_out = no
 		}
 		position = 0
@@ -35,7 +35,7 @@ inherichance_title_rank = {
 		ordered_held_title = {
 			limit = {
 				exists = previous_holder
-				previous_holder = scope:player
+				previous_holder = scope:deceased
 			}
 			position = 0
 			order_by = tier


### PR DESCRIPTION
Early on the scope player gets defined, which by my understanding is the same as deceased. But other then deceased is not only available in the gold path but also in the title path. Therefore eliminating the error that happens in line 5 of this file when you pick underdog as heir choice.